### PR TITLE
PEP 440 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class TestCommand(Command):
         unittest.main(tests, argv=sys.argv[:1])
 
 
-version = "0.17.cdc_fix"
+version = "0.17+cdcfix"
 
 setup(
     name="mysql-replication",


### PR DESCRIPTION
pep 440 dictates strict version naming rules.
Changing version format so future pip versions can still handle it, in case anything changes